### PR TITLE
Don't reset immediately. Its jarring.

### DIFF
--- a/src/fat.c
+++ b/src/fat.c
@@ -235,8 +235,14 @@ void write_block(uint32_t block_no, uint8_t *data, bool quiet, WriteState *state
                 state->writtenMask[pos] |= mask;
                 state->numWritten++;
             }
-            if (state->numWritten >= state->numBlocks)
-                resetIntoApp();
+            // We're done writing so reset everything so we can write another file.
+            if (state->numWritten >= state->numBlocks) {
+                state->numWritten = 0;
+                for (int i = 0; i < state->numBlocks / 8 + 1; i++) {
+                    state->writtenMask[i] = 0;
+                }
+                state->numBlocks = 0;
+            }
         }
     } else {
         resetHorizon = timerHigh + 300;


### PR DESCRIPTION
I'm not a fan of getting the unsafe eject warnings on OSes so this turns off the auto reset and replaces it with resetting the state in case another file is dragged over.

I think this should be fine with PXT because it appears you are moving to WebUSB and/or HID.