### PR TITLE
Allowed Bootloader to build WITHOUT a LED_PIN defined.

### DIFF
--- a/inc/uf2.h
+++ b/inc/uf2.h
@@ -17,7 +17,7 @@
 #undef DISABLE
 #undef ENABLE
 
-// always go for crystalless - smaller and more compatiable
+// always go for crystalless - smaller and more compatible
 #ifndef CRYSTALLESS
 #define CRYSTALLESS 1
 #endif
@@ -249,9 +249,16 @@ void led_signal(void);
 void led_init(void);
 void RGBLED_set_color(uint32_t color);
 
+// Not all targets have a LED
+#if defined(LED_PIN) 
 #define LED_MSC_OFF() PINOP(LED_PIN, OUTCLR)
 #define LED_MSC_ON() PINOP(LED_PIN, OUTSET)
 #define LED_MSC_TGL() PINOP(LED_PIN, OUTTGL)
+#else
+#define LED_MSC_OFF() 
+#define LED_MSC_ON() 
+#define LED_MSC_TGL() 
+#endif
 
 extern uint32_t timerHigh, resetHorizon;
 void timerTick(void);

--- a/src/utils.c
+++ b/src/utils.c
@@ -141,7 +141,9 @@ void led_signal() {
 }
 
 void led_init() {
+#if defined(LED_PIN)    
     PINOP(LED_PIN, DIRSET);
+#endif    
     LED_MSC_ON();
 
 #if defined(BOARD_RGBLED_CLOCK_PIN)


### PR DESCRIPTION
This is a small change to allow the code to build properly if NO Status LED is defined by the target board.