### PR TITLE
Add familyID and fix FAT16 bug

### DIFF
--- a/src/fat.c
+++ b/src/fat.c
@@ -72,6 +72,8 @@ const char indexFile[] = //
     "</html>\n";
 #endif
 
+// WARNING -- code presumes only one NULL .content for .UF2 file
+//            and requires it be the last element of the array
 static const struct TextFile info[] = {
     {.name = "INFO_UF2TXT", .content = infoUf2File},
 #if USE_INDEX_HTM
@@ -79,11 +81,12 @@ static const struct TextFile info[] = {
 #endif
     {.name = "CURRENT UF2"},
 };
-#define NUM_INFO (sizeof(info) / sizeof(info[0]))
+#define NUM_FILES (sizeof(info) / sizeof(info[0]))
+#define NUM_DIRENTRIES (NUM_FILES + 1) // Code adds volume label as first root directory entry
 
 #define UF2_SIZE (FLASH_SIZE * 2)
 #define UF2_SECTORS (UF2_SIZE / 512)
-#define UF2_FIRST_SECTOR (NUM_INFO + 1)
+#define UF2_FIRST_SECTOR (NUM_FILES + 1) // WARNING -- code presumes each non-UF2 file content fits in single sector
 #define UF2_LAST_SECTOR (UF2_FIRST_SECTOR + UF2_SECTORS - 1)
 #endif
 
@@ -96,6 +99,12 @@ static const struct TextFile info[] = {
 #define START_ROOTDIR (START_FAT1 + SECTORS_PER_FAT)
 #define START_CLUSTERS (START_ROOTDIR + ROOT_DIR_SECTORS)
 
+// all directory entries must fit in a single sector
+// because otherwise current code overflows buffer
+#define DIRENTRIES_PER_SECTOR (512/sizeof(DirEntry))
+STATIC_ASSERT(NUM_DIRENTRIES < DIRENTRIES_PER_SECTOR * ROOT_DIR_SECTORS);
+
+
 static const FAT_BootBlock BootBlock = {
     .JumpInstruction = {0xeb, 0x3c, 0x90},
     .OEMInfo = "UF2 UF2 ",
@@ -103,12 +112,13 @@ static const FAT_BootBlock BootBlock = {
     .SectorsPerCluster = 1,
     .ReservedSectors = RESERVED_SECTORS,
     .FATCopies = 2,
-    .RootDirectoryEntries = (ROOT_DIR_SECTORS * 512 / 32),
+    .RootDirectoryEntries = (ROOT_DIR_SECTORS * 512 / DIRENTRIES_PER_SECTOR),
     .TotalSectors16 = NUM_FAT_BLOCKS - 2,
     .MediaDescriptor = 0xF8,
     .SectorsPerFAT = SECTORS_PER_FAT,
     .SectorsPerTrack = 1,
     .Heads = 1,
+    .PhysicalDriveNum = 0x80, // to match MediaDescriptor of 0xF8
     .ExtendedBootSig = 0x29,
     .VolumeSerialNumber = 0x00420042,
     .VolumeLabel = VOLUME_LABEL,
@@ -129,24 +139,27 @@ void read_block(uint32_t block_no, uint8_t *data) {
     memset(data, 0, 512);
     uint32_t sectionIdx = block_no;
 
-    if (block_no == 0) {
+    if (block_no == 0) { // Requested boot block
         memcpy(data, &BootBlock, sizeof(BootBlock));
         data[510] = 0x55;
         data[511] = 0xaa;
         // logval("data[0]", data[0]);
-    } else if (block_no < START_ROOTDIR) {
+    } else if (block_no < START_ROOTDIR) {  // Requested FAT table sector
         sectionIdx -= START_FAT0;
         // logval("sidx", sectionIdx);
         if (sectionIdx >= SECTORS_PER_FAT)
-            sectionIdx -= SECTORS_PER_FAT;
+            sectionIdx -= SECTORS_PER_FAT; // second FAT is same as the first...
 #if USE_FAT
         if (sectionIdx == 0) {
             data[0] = 0xf0;
-            for (int i = 1; i < NUM_INFO * 2 + 4; ++i) {
+            // WARNING -- code presumes only one NULL .content for .UF2 file
+            //            and all non-NULL .content fit in one sector
+            //            and requires it be the last element of the array
+            for (int i = 1; i < NUM_FILES * 2 + 4; ++i) {
                 data[i] = 0xff;
             }
         }
-        for (int i = 0; i < 256; ++i) {
+        for (int i = 0; i < 256; ++i) { // Generate the FAT chain for the firmware "file"
             uint32_t v = sectionIdx * 256 + i;
             if (UF2_FIRST_SECTOR <= v && v <= UF2_LAST_SECTOR)
                 ((uint16_t *)(void *)data)[i] = v == UF2_LAST_SECTOR ? 0xffff : v + 1;
@@ -157,26 +170,29 @@ void read_block(uint32_t block_no, uint8_t *data) {
 #endif
     }
 #if USE_FAT
-    else if (block_no < START_CLUSTERS) {
+    else if (block_no < START_CLUSTERS) { // Requested sector of the root directory
         sectionIdx -= START_ROOTDIR;
         if (sectionIdx == 0) {
             DirEntry *d = (void *)data;
             padded_memcpy(d->name, BootBlock.VolumeLabel, 11);
             d->attrs = 0x28;
-            for (int i = 0; i < NUM_INFO; ++i) {
+            for (int i = 0; i < NUM_FILES; ++i) {
                 d++;
                 const struct TextFile *inf = &info[i];
                 d->size = inf->content ? strlen(inf->content) : UF2_SIZE;
                 d->startCluster = i + 2;
                 padded_memcpy(d->name, inf->name, 11);
+                d->createDate = 0x4d99;
+                d->updateDate = 0x4d99;
             }
         }
-    } else {
+    } else { // Requested sector from file space
         sectionIdx -= START_CLUSTERS;
-        if (sectionIdx < NUM_INFO - 1) {
+        // WARNING -- code presumes all but last file take exactly one sector
+        if (sectionIdx < NUM_FILES - 1) {
             memcpy(data, info[sectionIdx].content, strlen(info[sectionIdx].content));
         } else {
-            sectionIdx -= NUM_INFO - 1;
+            sectionIdx -= NUM_FILES - 1;
             uint32_t addr = sectionIdx * 256;
             if (addr < FLASH_SIZE) {
                 UF2_Block *bl = (void *)data;
@@ -187,6 +203,8 @@ void read_block(uint32_t block_no, uint8_t *data) {
                 bl->numBlocks = FLASH_SIZE / 256;
                 bl->targetAddr = addr;
                 bl->payloadSize = 256;
+                bl->flags |= UF2_FLAG_FAMILYID_PRESENT;
+                bl->familyID = UF2_FAMILY;
                 memcpy(bl->data, (void *)addr, bl->payloadSize);
             }
         }


### PR DESCRIPTION
Add many comments and static compile-time assertions,
which do not add to code size, but document unwritten
presumptions of the code.

Code changes:
1. Set boot sector .PhysicalDriveNum to 0x80
2. Set a valid date for file creation and update.  This fixes ability to list files in DOS / CMD.
3. Add the family ID to the generated UF2 file.