### PR TITLE
Fix CSW signatures, and unify FAT media descriptors

### DIFF
--- a/src/fat.c
+++ b/src/fat.c
@@ -115,11 +115,11 @@ static const FAT_BootBlock BootBlock = {
     .FATCopies = 2,
     .RootDirectoryEntries = (ROOT_DIR_SECTORS * DIRENTRIES_PER_SECTOR),
     .TotalSectors16 = NUM_FAT_BLOCKS - 2,
-    .MediaDescriptor = 0xF8,
+    .MediaDescriptor = 0xf0, // typical for unpartitioned disks
     .SectorsPerFAT = SECTORS_PER_FAT,
     .SectorsPerTrack = 1,
     .Heads = 1,
-    .PhysicalDriveNum = 0x80, // to match MediaDescriptor of 0xF8
+    .PhysicalDriveNum = 0x00, // to match MediaDescriptor of 0xf0
     .ExtendedBootSig = 0x29,
     .VolumeSerialNumber = 0x00420042,
     .VolumeLabel = VOLUME_LABEL,
@@ -152,7 +152,7 @@ void read_block(uint32_t block_no, uint8_t *data) {
             sectionIdx -= SECTORS_PER_FAT; // second FAT is same as the first...
 #if USE_FAT
         if (sectionIdx == 0) {
-            data[0] = 0xf0;
+            data[0] = 0xf0; // must match MediaDescriptor
             // WARNING -- code presumes only one NULL .content for .UF2 file
             //            and all non-NULL .content fit in one sector
             //            and requires it be the last element of the array

--- a/src/msc.c
+++ b/src/msc.c
@@ -84,7 +84,7 @@ void msc_reset(void) {
 //! Structure to receive a CBW packet
 static struct usb_msc_cbw udi_msc_cbw;
 //! Structure to send a CSW packet
-static struct usb_msc_csw udi_msc_csw = {.dCSWSignature = CPU_TO_BE32(USB_CSW_SIGNATURE)};
+static struct usb_msc_csw udi_msc_csw = {.dCSWSignature = cpu_to_le32(USB_CSW_SIGNATURE)};
 //! Structure with current SCSI sense data
 static struct scsi_request_sense_data udi_msc_sense;
 
@@ -281,7 +281,7 @@ bool try_read_cbw(struct usb_msc_cbw *cbw, uint8_t ep, PacketBuffer *handoverCac
 #if USE_MSC_CHECKS
     // Check CBW integrity:
     // transfer status/CBW length/CBW signature
-    if ((sizeof(*cbw) != nb_received) || (cbw->dCBWSignature != CPU_TO_BE32(USB_CBW_SIGNATURE))) {
+    if ((sizeof(*cbw) != nb_received) || (cbw->dCBWSignature != cpu_to_le32(USB_CBW_SIGNATURE))) {
         if (handoverCache)
             resetIntoBootloader();
         // (5.2.1) Devices receiving a CBW with an invalid signature should
@@ -783,7 +783,7 @@ static void handover_flash(UF2_HandoverArgs *handover, PacketBuffer *handoverCac
 static void process_handover_initial(UF2_HandoverArgs *handover, PacketBuffer *handoverCache,
                                      WriteState *state) {
     struct usb_msc_csw csw = {.dCSWTag = handover->cbw_tag,
-                              .dCSWSignature = CPU_TO_BE32(USB_CSW_SIGNATURE),
+                              .dCSWSignature = cpu_to_le32(USB_CSW_SIGNATURE),
                               .bCSWStatus = USB_CSW_STATUS_PASS,
                               .dCSWDataResidue = 0};
     // write out the block passed from user space
@@ -807,7 +807,7 @@ static void process_handover(UF2_HandoverArgs *handover, PacketBuffer *handoverC
     }
 
     struct usb_msc_csw csw = {.dCSWTag = cbw.dCBWTag,
-                              .dCSWSignature = CPU_TO_BE32(USB_CSW_SIGNATURE),
+                              .dCSWSignature = cpu_to_le32(USB_CSW_SIGNATURE),
                               .bCSWStatus = USB_CSW_STATUS_PASS,
                               .dCSWDataResidue = le32_to_cpu(cbw.dCBWDataTransferLength)};
 


### PR DESCRIPTION
There are two issues that prevent some OSs (such as FreeBSD) from being able to mount the filesystem exposed by the bootloader.  Both are failed cross-checks that are ignored by many OSs, but are tested by some (such as FreeBSD).

First, the CSW signature is being sent in big-endian instead of little-endian.  While the wrapped SCSI packet is supposed to be in big-endian, the wrapper itself is part of the USB protocol and hence little-endian.

Second, the media descriptor is given as 0xf8 in the boot sector, but 0xf0 in the FAT.  These should match.

More details are in the individual commit messages.