### PR TITLE
add LED_ACTIVE_LOW to switch led correct on different connections

### DIFF
--- a/inc/uf2.h
+++ b/inc/uf2.h
@@ -276,9 +276,15 @@ void RGBLED_set_color(uint32_t color);
 
 // Not all targets have a LED
 #if defined(LED_PIN)
+#if defined(LED_ACTIVE_LOW)
+#define LED_MSC_OFF() PINOP(LED_PIN, OUTSET)
+#define LED_MSC_ON() PINOP(LED_PIN, OUTCLR)
+#define LED_MSC_TGL() PINOP(LED_PIN, OUTTGL)
+#else
 #define LED_MSC_OFF() PINOP(LED_PIN, OUTCLR)
 #define LED_MSC_ON() PINOP(LED_PIN, OUTSET)
 #define LED_MSC_TGL() PINOP(LED_PIN, OUTTGL)
+#endif
 #else
 #define LED_MSC_OFF()
 #define LED_MSC_ON()


### PR DESCRIPTION
Add an define for the status LED to switch correct if they are connect to switch on active LOW.

define name: LED_ACTIVE_LOW

if this is not defined it will work like expected