### PR TITLE
fix Wait States in samd51 init

### DIFF
--- a/src/init_samd51.c
+++ b/src/init_samd51.c
@@ -1,8 +1,8 @@
 #include "uf2.h"
 
 void system_init(void) {
-    /* Set 1 Flash Wait State for 48MHz */
-    NVMCTRL->CTRLA.reg |= NVMCTRL_CTRLA_RWS(0);
+    /* Set 2 Flash Wait State for 48MHz , refer to TAB 56.6 in datasheet*/
+    NVMCTRL->CTRLA.reg |= NVMCTRL_CTRLA_RWS(2);
 
     // Output GCLK0 to Metro M4 D5. This way we can see if/when we mess it up.
     //PORT->Group[1].PINCFG[14].bit.PMUXEN = true;


### PR DESCRIPTION
The Wait state Config in init samd51 is wrong, we set the clock to 48 MHz we have to set WS to 2 (I add a picture from 125 °C). With WS= 0 (means no wait state) there is a high chance to get serious trouble.

<img width="1360" alt="WS_config" src="https://github.com/microsoft/uf2-samdx1/assets/20142175/ef79a682-c4ec-4afc-a5ad-81b656cebdb7">

The data sheet can be found here : [samd51 datasheet](https://ww1.microchip.com/downloads/aemDocuments/documents/MCU32/ProductDocuments/DataSheets/SAM-D5x-E5x-Family-Data-Sheet-DS60001507.pdf)

