### PR TITLE
add wait to get line on potential (pullup/pulldown) without external pullup/down

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -112,6 +112,10 @@ static void check_start_application(void) {
   #endif
     PINCFG(HOLD_PIN) = pincfg.reg;
 
+  #if defined(HOLD_PIN_PULLDOWN) || defined(HOLD_PIN_PULLUP)
+    delay(2); // delay for 2ms to get pin on potential
+  #endif
+  
     if (PINIP(HOLD_PIN) == HOLD_STATE) {
         /* Stay in bootloader */
         return;


### PR DESCRIPTION
Hi,

We got problems by removing an external resistor on our hold pin. Since there is a config for the internal pullup, we remove the physical one. This ends up in holding the board in the bootloder, because we load the pin config and directly check the pin status, but to get the pin on the pullup state needs a few ms to get on the potential. 
as I see the pullups has an Resistance of 20-60kOhm.
<img width="860" alt="Screenshot 2023-12-21 at 10 46 34" src="https://github.com/microsoft/uf2-samdx1/assets/20142175/1f77b02a-1bf7-414d-95bd-6d6ef1b5742d">



As I see @dhalbert don't get the problem as they don't use the HOLD_PIN ?

regards
